### PR TITLE
test_ucode: address UnusedElaboratable warning.

### DIFF
--- a/tests/sim/test_ucode.py
+++ b/tests/sim/test_ucode.py
@@ -1,6 +1,7 @@
 import pytest
 import enum
 
+from amaranth import Fragment
 from io import StringIO
 
 from sentinel.ucoderom import UCodeROM
@@ -36,7 +37,7 @@ class Bar(enum.Enum):
 @pytest.mark.clks((1.0 / 12e6,))
 def test_ucode_layout_gen(sim_mod):
     _, m = sim_mod
-    m.elaborate(None)
+    Fragment.get(m, None)
 
 
 @pytest.mark.module(UCodeROM(main_file=StringIO(M5META_TEST_FILE),

--- a/tests/sim/test_ucode.py
+++ b/tests/sim/test_ucode.py
@@ -37,6 +37,7 @@ class Bar(enum.Enum):
 @pytest.mark.clks((1.0 / 12e6,))
 def test_ucode_layout_gen(sim_mod):
     _, m = sim_mod
+    # Use Fragment.get to ensure the Module is marked as used.
     Fragment.get(m, None)
 
 


### PR DESCRIPTION
Fixes #17.

This is in fact an `UnusedElaboratable` being reported. If you stick `# amaranth: UnusedElaboratable=no` at the top of `ucoderom.py`, it goes away.

The origin is `test_ucode_layout_gen`:

https://github.com/cr1901/sentinel/blob/0bd1a79cf94623aacce85e4fb7aeb59e499c1624/tests/sim/test_ucode.py#L32-L39

It doesn't happen if you run it in isolation, I'm guessing due to how all the `MustUse` machinery works (or some interaction with `SimulatorFixture`), but one other test before it is enough:

```console
$ pdm test tests/sim/test_top.py::test_exception tests/sim/test_ucode.py::test_ucode_layout_gen
=================================== test session starts ===================================
platform darwin -- Python 3.12.3, pytest-8.1.1, pluggy-1.4.0
rootdir: /Users/kivikakk/g/sentinel
configfile: pyproject.toml
collected 2 items

tests/sim/test_top.py .                                                             [ 50%]
tests/sim/test_ucode.py .                                                           [100%]

==================================== 2 passed in 1.44s ====================================
/Users/kivikakk/g/sentinel/src/sentinel/ucoderom.py:69: UnusedElaboratable: <amaranth.hdl._dsl.Module object at 0x1072cb1d0> created but never used
  m = Module()
UnusedElaboratable: Enable tracemalloc to get the object allocation traceback
```

`Fragment.get` calls `elaborate` and sets the "used" flag, so this stops the warning.